### PR TITLE
Fix issue runtime for linux

### DIFF
--- a/src-tauri/src/version_manager.rs
+++ b/src-tauri/src/version_manager.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 pub const VERSION_MANIFEST_URL: &str = "cdn.bymrefitted.com/versionManifest.json";
 pub const SWFS_URL: &str = "cdn.bymrefitted.com/launcher/swfs/";
-pub const RUNTIMES_DIR: &str = "bymr-downloads/runtimes";
+pub const RUNTIMES_DIR: &str = "cdn.bymrefitted.com/launcher/runtimes/";
 
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct VersionManifest {


### PR DESCRIPTION
Added url to download the runtime in linux as the url from before was a directory. 