### PR TITLE
Fix Launcher not working outside Windows

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "app"
-version = "0.2.2"
+name = "BYMR"
+version = "0.2.3"
 description = "A Tauri App"
-authors = ["you"]
+authors = ["BYM Team"]
 license = ""
 repository = ""
-default-run = "app"
+default-run = "BYMR"
 edition = "2021"
 rust-version = "1.60"
 

--- a/src-tauri/src/version_manager.rs
+++ b/src-tauri/src/version_manager.rs
@@ -38,25 +38,17 @@ pub async fn get_current_game_version() -> Result<String, String> {
     }
 }
 
-fn ensure_folder_exists(runtime_path: &Path) -> std::io::Result<()> {
-    if !runtime_path.exists() {
-        fs::create_dir_all(runtime_path)?;
-    }
-    Ok(())
-}
-
 pub async fn download_runtime(
-    (runtime_path, file_extension): (PathBuf, String),
+    runtime_path: PathBuf, 
+    runtime_executable: String,
     use_https: bool,
 ) -> Result<(), String> {
-    ensure_folder_exists(Path::new(RUNTIMES_DIR)).expect("Could not create runtimes folder");
-
-    download_file(&runtime_path, &file_extension, use_https)
+    download_file(&runtime_path, &runtime_executable, use_https)
         .await
         .map_err(|err| err.to_string())
 }
 
-pub fn get_platform_flash_runtime(platform: &str) -> Result<(PathBuf, String), String> {
+pub fn get_platform_flash_runtime(platform: &str, appdata_path: PathBuf) -> Result<(PathBuf, String), String> {
     let flash_runtimes = match platform {
         "windows" => Ok("flashplayer.exe".to_string()),
         "darwin" => Ok("flashplayer.dmg".to_string()),
@@ -64,5 +56,5 @@ pub fn get_platform_flash_runtime(platform: &str) -> Result<(PathBuf, String), S
         _ => Err(format!("unsupported platform: {}", platform)),
     };
 
-    flash_runtimes.map(|runtime| (PathBuf::from(RUNTIMES_DIR).join(runtime.clone()), runtime))
+    flash_runtimes.map(|runtime| (appdata_path.join(runtime.clone()), runtime))
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   },
   "package": {
     "productName": "bymr-launcher",
-    "version": "0.2.2"
+    "version": "0.2.3"
   },
   "tauri": {
     "allowlist": {
@@ -28,7 +28,7 @@
       "http": {
         "all": true,
         "request": true,
-        "scope": ["https://localhost/*", "https://api.bymrefitted.com/*"] 
+        "scope": ["https://localhost/*", "https://api.bymrefitted.com/*"]
       }
     },
     "bundle": {


### PR DESCRIPTION
The current implementation of the launcher tries to create the directory `bym-downloads` alongside with the `runtime` directory inside it. This approach works fine on Windows but has caused problems on non-windows OS (Mainly Linux and allegedly MacOS) as the file structure is severely different.

Hopefully Tauri has a cross-platform method that allows us to get the directory for the project's Data Folder as seen [here](https://v1.tauri.app/v1/api/js/path/#appdatadir) (for JS) and [here](https://docs.rs/tauri/1.8.1/tauri/struct.PathResolver.html#method.app_data_dir) (for Rust). Here is the explanation for the `appDataDir` function that was used on this PR: 

> Returns the path to the suggested directory for your app's data files. Resolves to ${dataDir}/${bundleIdentifier}, where bundleIdentifier is the value [tauri.bundle.identifier](https://tauri.app/v1/api/config/#bundleconfig.identifier) is configured in tauri.conf.json.

I've also changed the app name on `Cargo.toml` to `BYMR` but ReactX has to check if that affects the OTA Updates thing.